### PR TITLE
[bug-EPMCDLAB-792]: Fixed SSL certificate uploading in GitLab script deploy

### DIFF
--- a/infrastructure-provisioning/src/general/lib/os/fab.py
+++ b/infrastructure-provisioning/src/general/lib/os/fab.py
@@ -614,7 +614,8 @@ def install_ungit(os_user, certfile):
             sudo('systemctl daemon-reload')
             sudo('systemctl enable ungit.service')
             sudo('systemctl start ungit.service')
-            if get_gitlab_cert('{}-ssn-bucket'.format(os.environ['conf_service_base_name']), certfile):
+            bucket_name = ('{}-ssn-bucket'.format(os.environ['conf_service_base_name'])).lower().replace('_', '-')
+            if get_gitlab_cert(bucket_name, certfile):
                 put(certfile, certfile)
                 sudo('chown root:root {}'.format(certfile))
             sudo('touch /home/{}/.ensure_dir/ungit_ensured'.format(os_user))

--- a/infrastructure-provisioning/src/ssn/scripts/gitlab_deploy.py
+++ b/infrastructure-provisioning/src/ssn/scripts/gitlab_deploy.py
@@ -210,7 +210,7 @@ if __name__ == "__main__":
             terminate_gitlab()
             sys.exit(1)
 
-        bucket_name = '{}-ssn-bucket'.format(os.environ['conf_service_base_name'])
+        bucket_name = ('{}-ssn-bucket'.format(os.environ['conf_service_base_name'])).lower().replace('_', '-')
         for filename in os.listdir(head):
             if filename.endswith('.crt'):
                 put_to_bucket(bucket_name, os.path.join(head, filename), filename)


### PR DESCRIPTION
Fixed bucket name, which can't contains underscores.