### PR TITLE
[EPMCDLAB-1384]: Fixed removing remote kernels from notebook image

### DIFF
--- a/infrastructure-provisioning/src/deeplearning/scripts/configure_deep_learning_node.py
+++ b/infrastructure-provisioning/src/deeplearning/scripts/configure_deep_learning_node.py
@@ -156,4 +156,4 @@ if __name__ == "__main__":
     
     #POST INSTALLATION PROCESS
     print("Updating pyOpenSSL library")
-    update_pyopenssl_lib()
+    update_pyopenssl_lib(args.os_user)

--- a/infrastructure-provisioning/src/general/conf/dlab.ini
+++ b/infrastructure-provisioning/src/general/conf/dlab.ini
@@ -229,4 +229,4 @@ slave_instance_spot_pct_price = 70
 ### Count of slave nodes for Data Engine
 instance_count = 3
 ### Type of notebooks for creating Data Engine from notebook images
-image_notebooks = tensor,deeplearning
+image_notebooks = jupyter,tensor,deeplearning

--- a/infrastructure-provisioning/src/general/conf/dlab.ini
+++ b/infrastructure-provisioning/src/general/conf/dlab.ini
@@ -229,4 +229,4 @@ slave_instance_spot_pct_price = 70
 ### Count of slave nodes for Data Engine
 instance_count = 3
 ### Type of notebooks for creating Data Engine from notebook images
-image_notebooks = jupyter,tensor,deeplearning
+image_notebooks = tensor,deeplearning

--- a/infrastructure-provisioning/src/general/lib/os/fab.py
+++ b/infrastructure-provisioning/src/general/lib/os/fab.py
@@ -472,14 +472,15 @@ def replace_multi_symbols(string, symbol, symbol_cut=False):
         traceback.print_exc(file=sys.stdout)
 
 
-def update_pyopenssl_lib():
-    try:
-        print("Updating pyOpenssl lib")
-        if exists('/usr/bin/pip3'):
-            sudo('pip3 install -U pyopenssl')
-        sudo('pip2 install -U pyopenssl')
-    except:
-        sys.exit(1)
+def update_pyopenssl_lib(os_user):
+    if not exists('/home/{}/.ensure_dir/pyopenssl_updated'.format(os_user)):
+        try:
+            if exists('/usr/bin/pip3'):
+                sudo('pip3 install -U pyopenssl')
+            sudo('pip2 install -U pyopenssl')
+            sudo('touch /home/{}/.ensure_dir/pyopenssl_updated'.format(os_user))
+        except:
+            sys.exit(1)
 
 
 def find_cluster_kernels():

--- a/infrastructure-provisioning/src/general/lib/os/fab.py
+++ b/infrastructure-provisioning/src/general/lib/os/fab.py
@@ -480,3 +480,15 @@ def update_pyopenssl_lib():
         sudo('pip2 install -U pyopenssl')
     except:
         sys.exit(1)
+
+
+def find_cluster_kernels():
+    try:
+        with settings(sudo_user='root'):
+            de = [i for i in sudo('find /opt/ -maxdepth 1 -name "*-de-*" -type d | rev | '
+                                  'cut -f 1 -d "/" | rev | xargs -r').split(' ') if i != '']
+            des =  [i for i in sudo('find /opt/ -maxdepth 2 -name "*-des-*" -type d | rev | '
+                                    'cut -f 1,2 -d "/" | rev | xargs -r').split(' ') if i != '']
+        return (de, des)
+    except:
+        sys.exit(1)

--- a/infrastructure-provisioning/src/general/scripts/aws/common_prepare_notebook.py
+++ b/infrastructure-provisioning/src/general/scripts/aws/common_prepare_notebook.py
@@ -87,6 +87,7 @@ if __name__ == "__main__":
     tag = {"Key": notebook_config['tag_name'],
            "Value": "{}-{}-subnet".format(notebook_config['service_base_name'], os.environ['edge_user_name'])}
     notebook_config['subnet_cidr'] = get_subnet_by_tag(tag)
+    keyfile_name = "{}{}.pem".format(os.environ['conf_key_dir'], os.environ['conf_key_name'])
 
     with open('/root/result.json', 'w') as f:
         data = {"notebook_name": notebook_config['instance_name'], "error": ""}
@@ -110,3 +111,4 @@ if __name__ == "__main__":
     except Exception as err:
         append_result("Failed to create instance.", str(err))
         sys.exit(1)
+

--- a/infrastructure-provisioning/src/general/scripts/aws/common_remove_remote_kernels.py
+++ b/infrastructure-provisioning/src/general/scripts/aws/common_remove_remote_kernels.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+
+# *****************************************************************************
+#
+# Copyright (c) 2016, EPAM SYSTEMS INC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ******************************************************************************
+
+import os
+import sys
+import argparse
+from fabric.api import *
+from dlab.fab import find_cluster_kernels
+from dlab.actions_lib import *
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--hostname', type=str, default='')
+parser.add_argument('--keyfile', type=str, default='')
+parser.add_argument('--os_user', type=str, default='')
+parser.add_argument('--nb_tag_name', type=str, default='')
+parser.add_argument('--nb_tag_value', type=str, default='')
+args = parser.parse_args()
+
+
+if __name__ == "__main__":
+    print('Configure connections')
+    env['connection_attempts'] = 100
+    env.key_filename = [args.keyfile]
+    env.host_string = args.os_user + '@' + args.hostname
+
+    try:
+        de_clusters, des_clusters = find_cluster_kernels()
+        for cluster in de_clusters:
+            remove_dataengine_kernels(args.nb_tag_name, args.nb_tag_value, args.os_user, args.keyfile, cluster)
+        for cluster in des_clusters:
+            remove_kernels(cluster.split('/')[1], args.nb_tag_name, args.nb_tag_value,
+                           args.os_user, args.keyfile, cluster.split('/')[0])
+    except Exception as err:
+        print('Failed to remove cluster kernels.', str(err))
+        sys.exit(1)
+
+    sys.exit(0)

--- a/infrastructure-provisioning/src/general/scripts/aws/deeplearning_configure.py
+++ b/infrastructure-provisioning/src/general/scripts/aws/deeplearning_configure.py
@@ -178,6 +178,23 @@ if __name__ == "__main__":
         remove_ec2(notebook_config['tag_name'], notebook_config['instance_name'])
         sys.exit(1)
 
+    try:
+        logging.info('[POST CONFIGURING PROCESS]')
+        print('[POST CONFIGURING PROCESS')
+        if notebook_config['notebook_image_name'] not in [notebook_config['expected_image_name'], 'None']:
+            params = "--hostname {} --keyfile {} --os_user {} --nb_tag_name {} --nb_tag_value {}" \
+                .format(instance_hostname, keyfile_name, notebook_config['dlab_ssh_user'],
+                        notebook_config['tag_name'], notebook_config['instance_name'])
+            try:
+                local("~/scripts/{}.py {}".format('common_remove_remote_kernels', params))
+            except:
+                traceback.print_exc()
+                raise Exception
+    except Exception as err:
+        append_result("Failed to post configuring instance.", str(err))
+        remove_ec2(notebook_config['tag_name'], notebook_config['instance_name'])
+        sys.exit(1)
+
     if notebook_config['shared_image_enabled'] == 'true':
         try:
             print('[CREATING AMI]')

--- a/infrastructure-provisioning/src/general/scripts/aws/jupyter_configure.py
+++ b/infrastructure-provisioning/src/general/scripts/aws/jupyter_configure.py
@@ -180,16 +180,18 @@ if __name__ == "__main__":
     try:
         logging.info('[POST CONFIGURING PROCESS]')
         print('[POST CONFIGURING PROCESS')
-        params = "--hostname {} --keyfile {} --os_user {} --nb_tag_name {} --nb_tag_value {}" \
-            .format(instance_hostname, keyfile_name, notebook_config['dlab_ssh_user'],
-                    notebook_config['tag_name'], notebook_config['instance_name'])
-        try:
-            local("~/scripts/{}.py {}".format('common_remove_remote_kernels', params))
-        except:
-            traceback.print_exc()
-            raise Exception
+        if notebook_config['notebook_image_name'] not in [notebook_config['expected_image_name'], 'None']:
+            params = "--hostname {} --keyfile {} --os_user {} --nb_tag_name {} --nb_tag_value {}" \
+                .format(instance_hostname, keyfile_name, notebook_config['dlab_ssh_user'],
+                        notebook_config['tag_name'], notebook_config['instance_name'])
+            try:
+                local("~/scripts/{}.py {}".format('common_remove_remote_kernels', params))
+            except:
+                traceback.print_exc()
+                raise Exception
     except Exception as err:
         append_result("Failed to post configuring instance.", str(err))
+        remove_ec2(notebook_config['tag_name'], notebook_config['instance_name'])
         sys.exit(1)
 
     if notebook_config['shared_image_enabled'] == 'true':

--- a/infrastructure-provisioning/src/general/scripts/aws/jupyter_configure.py
+++ b/infrastructure-provisioning/src/general/scripts/aws/jupyter_configure.py
@@ -177,6 +177,21 @@ if __name__ == "__main__":
         remove_ec2(notebook_config['tag_name'], notebook_config['instance_name'])
         sys.exit(1)
 
+    try:
+        logging.info('[POST CONFIGURING PROCESS]')
+        print('[POST CONFIGURING PROCESS')
+        params = "--hostname {} --keyfile {} --os_user {} --nb_tag_name {} --nb_tag_value {}" \
+            .format(instance_hostname, keyfile_name, notebook_config['dlab_ssh_user'],
+                    notebook_config['tag_name'], notebook_config['instance_name'])
+        try:
+            local("~/scripts/{}.py {}".format('common_remove_remote_kernels', params))
+        except:
+            traceback.print_exc()
+            raise Exception
+    except Exception as err:
+        append_result("Failed to post configuring instance.", str(err))
+        sys.exit(1)
+
     if notebook_config['shared_image_enabled'] == 'true':
         try:
             print('[CREATING AMI]')

--- a/infrastructure-provisioning/src/general/scripts/aws/rstudio_configure.py
+++ b/infrastructure-provisioning/src/general/scripts/aws/rstudio_configure.py
@@ -178,6 +178,23 @@ if __name__ == "__main__":
         remove_ec2(notebook_config['tag_name'], notebook_config['instance_name'])
         sys.exit(1)
 
+    try:
+        logging.info('[POST CONFIGURING PROCESS]')
+        print('[POST CONFIGURING PROCESS')
+        if notebook_config['notebook_image_name'] not in [notebook_config['expected_image_name'], 'None']:
+            params = "--hostname {} --keyfile {} --os_user {} --nb_tag_name {} --nb_tag_value {}" \
+                .format(instance_hostname, keyfile_name, notebook_config['dlab_ssh_user'],
+                        notebook_config['tag_name'], notebook_config['instance_name'])
+            try:
+                local("~/scripts/{}.py {}".format('common_remove_remote_kernels', params))
+            except:
+                traceback.print_exc()
+                raise Exception
+    except Exception as err:
+        append_result("Failed to post configuring instance.", str(err))
+        remove_ec2(notebook_config['tag_name'], notebook_config['instance_name'])
+        sys.exit(1)
+
     if notebook_config['shared_image_enabled'] == 'true':
         try:
             print('[CREATING AMI]')

--- a/infrastructure-provisioning/src/general/scripts/aws/tensor_configure.py
+++ b/infrastructure-provisioning/src/general/scripts/aws/tensor_configure.py
@@ -179,6 +179,23 @@ if __name__ == "__main__":
         remove_ec2(notebook_config['tag_name'], notebook_config['instance_name'])
         sys.exit(1)
 
+    try:
+        logging.info('[POST CONFIGURING PROCESS]')
+        print('[POST CONFIGURING PROCESS')
+        if notebook_config['notebook_image_name'] not in [notebook_config['expected_image_name'], 'None']:
+            params = "--hostname {} --keyfile {} --os_user {} --nb_tag_name {} --nb_tag_value {}" \
+                .format(instance_hostname, keyfile_name, notebook_config['dlab_ssh_user'],
+                        notebook_config['tag_name'], notebook_config['instance_name'])
+            try:
+                local("~/scripts/{}.py {}".format('common_remove_remote_kernels', params))
+            except:
+                traceback.print_exc()
+                raise Exception
+    except Exception as err:
+        append_result("Failed to post configuring instance.", str(err))
+        remove_ec2(notebook_config['tag_name'], notebook_config['instance_name'])
+        sys.exit(1)
+
     if notebook_config['shared_image_enabled'] == 'true':
         try:
             print('[CREATING AMI]')

--- a/infrastructure-provisioning/src/general/scripts/aws/zeppelin_configure.py
+++ b/infrastructure-provisioning/src/general/scripts/aws/zeppelin_configure.py
@@ -193,6 +193,23 @@ if __name__ == "__main__":
         append_result("Failed to setup git credentials.", str(err))
         remove_ec2(notebook_config['tag_name'], notebook_config['instance_name'])
         sys.exit(1)
+    
+    try:
+        logging.info('[POST CONFIGURING PROCESS]')
+        print('[POST CONFIGURING PROCESS')
+        if notebook_config['notebook_image_name'] not in [notebook_config['expected_image_name'], 'None']:
+            params = "--hostname {} --keyfile {} --os_user {} --nb_tag_name {} --nb_tag_value {}" \
+                .format(instance_hostname, keyfile_name, notebook_config['dlab_ssh_user'],
+                        notebook_config['tag_name'], notebook_config['instance_name'])
+            try:
+                local("~/scripts/{}.py {}".format('common_remove_remote_kernels', params))
+            except:
+                traceback.print_exc()
+                raise Exception
+    except Exception as err:
+        append_result("Failed to post configuring instance.", str(err))
+        remove_ec2(notebook_config['tag_name'], notebook_config['instance_name'])
+        sys.exit(1)
 
     if notebook_config['shared_image_enabled'] == 'true':
         try:

--- a/infrastructure-provisioning/src/general/scripts/azure/common_remove_remote_kernels.py
+++ b/infrastructure-provisioning/src/general/scripts/azure/common_remove_remote_kernels.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+
+# *****************************************************************************
+#
+# Copyright (c) 2016, EPAM SYSTEMS INC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ******************************************************************************
+
+import os
+import sys
+import argparse
+from fabric.api import *
+from dlab.fab import find_cluster_kernels
+from dlab.actions_lib import *
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--hostname', type=str, default='')
+parser.add_argument('--keyfile', type=str, default='')
+parser.add_argument('--os_user', type=str, default='')
+parser.add_argument('--resource_group_name', type=str, default='')
+parser.add_argument('--notebook_name', type=str, default='')
+args = parser.parse_args()
+
+
+if __name__ == "__main__":
+    print('Configure connections')
+    env['connection_attempts'] = 100
+    env.key_filename = [args.keyfile]
+    env.host_string = args.os_user + '@' + args.hostname
+
+    try:
+        de_clusters, des_clusters = find_cluster_kernels()
+        for cluster in de_clusters:
+            AzureActions().remove_dataengine_kernels(args.resource_group_name, args.notebook_name,
+                                                     args.os_user, args.keyfile, cluster)
+    except Exception as err:
+        print('Failed to remove cluster kernels.', str(err))
+        sys.exit(1)
+
+    sys.exit(0)

--- a/infrastructure-provisioning/src/general/scripts/azure/deeplearning_configure.py
+++ b/infrastructure-provisioning/src/general/scripts/azure/deeplearning_configure.py
@@ -185,6 +185,23 @@ if __name__ == "__main__":
         AzureActions().remove_instance(notebook_config['resource_group_name'], notebook_config['instance_name'])
         sys.exit(1)
 
+    try:
+        logging.info('[POST CONFIGURING PROCESS]')
+        print('[POST CONFIGURING PROCESS')
+        if notebook_config['notebook_image_name'] not in [notebook_config['expected_image_name'], 'None']:
+            params = "--hostname {} --keyfile {} --os_user {} --resource_group_name {} --notebook_name {}" \
+                .format(instance_hostname, keyfile_name, notebook_config['dlab_ssh_user'],
+                        notebook_config['resource_group_name'], notebook_config['instance_name'])
+            try:
+                local("~/scripts/{}.py {}".format('common_remove_remote_kernels', params))
+            except:
+                traceback.print_exc()
+                raise Exception
+    except Exception as err:
+        append_result("Failed to post configuring instance.", str(err))
+        AzureActions().remove_instance(notebook_config['resource_group_name'], notebook_config['instance_name'])
+        sys.exit(1)
+
     if notebook_config['shared_image_enabled'] == 'true':
         try:
             print('[CREATING IMAGE]')

--- a/infrastructure-provisioning/src/general/scripts/azure/jupyter_configure.py
+++ b/infrastructure-provisioning/src/general/scripts/azure/jupyter_configure.py
@@ -184,6 +184,23 @@ if __name__ == "__main__":
         AzureActions().remove_instance(notebook_config['resource_group_name'], notebook_config['instance_name'])
         sys.exit(1)
 
+    try:
+        logging.info('[POST CONFIGURING PROCESS]')
+        print('[POST CONFIGURING PROCESS')
+        if notebook_config['notebook_image_name'] not in [notebook_config['expected_image_name'], 'None']:
+            params = "--hostname {} --keyfile {} --os_user {} --resource_group_name {} --notebook_name {}" \
+                .format(instance_hostname, keyfile_name, notebook_config['dlab_ssh_user'],
+                        notebook_config['resource_group_name'], notebook_config['instance_name'])
+            try:
+                local("~/scripts/{}.py {}".format('common_remove_remote_kernels', params))
+            except:
+                traceback.print_exc()
+                raise Exception
+    except Exception as err:
+        append_result("Failed to post configuring instance.", str(err))
+        AzureActions().remove_instance(notebook_config['resource_group_name'], notebook_config['instance_name'])
+        sys.exit(1)
+
     if notebook_config['shared_image_enabled'] == 'true':
         try:
             print('[CREATING IMAGE]')

--- a/infrastructure-provisioning/src/general/scripts/azure/rstudio_configure.py
+++ b/infrastructure-provisioning/src/general/scripts/azure/rstudio_configure.py
@@ -184,6 +184,23 @@ if __name__ == "__main__":
         AzureActions().remove_instance(notebook_config['resource_group_name'], notebook_config['instance_name'])
         sys.exit(1)
 
+    try:
+        logging.info('[POST CONFIGURING PROCESS]')
+        print('[POST CONFIGURING PROCESS')
+        if notebook_config['notebook_image_name'] not in [notebook_config['expected_image_name'], 'None']:
+            params = "--hostname {} --keyfile {} --os_user {} --resource_group_name {} --notebook_name {}" \
+                .format(instance_hostname, keyfile_name, notebook_config['dlab_ssh_user'],
+                        notebook_config['resource_group_name'], notebook_config['instance_name'])
+            try:
+                local("~/scripts/{}.py {}".format('common_remove_remote_kernels', params))
+            except:
+                traceback.print_exc()
+                raise Exception
+    except Exception as err:
+        append_result("Failed to post configuring instance.", str(err))
+        AzureActions().remove_instance(notebook_config['resource_group_name'], notebook_config['instance_name'])
+        sys.exit(1)
+
     if notebook_config['shared_image_enabled'] == 'true':
         try:
             print('[CREATING IMAGE]')

--- a/infrastructure-provisioning/src/general/scripts/azure/tensor_configure.py
+++ b/infrastructure-provisioning/src/general/scripts/azure/tensor_configure.py
@@ -183,6 +183,23 @@ if __name__ == "__main__":
         AzureActions().remove_instance(notebook_config['resource_group_name'], notebook_config['instance_name'])
         sys.exit(1)
 
+    try:
+        logging.info('[POST CONFIGURING PROCESS]')
+        print('[POST CONFIGURING PROCESS')
+        if notebook_config['notebook_image_name'] not in [notebook_config['expected_image_name'], 'None']:
+            params = "--hostname {} --keyfile {} --os_user {} --resource_group_name {} --notebook_name {}" \
+                .format(instance_hostname, keyfile_name, notebook_config['dlab_ssh_user'],
+                        notebook_config['resource_group_name'], notebook_config['instance_name'])
+            try:
+                local("~/scripts/{}.py {}".format('common_remove_remote_kernels', params))
+            except:
+                traceback.print_exc()
+                raise Exception
+    except Exception as err:
+        append_result("Failed to post configuring instance.", str(err))
+        AzureActions().remove_instance(notebook_config['resource_group_name'], notebook_config['instance_name'])
+        sys.exit(1)
+
     if notebook_config['shared_image_enabled'] == 'true':
         try:
             print('[CREATING IMAGE]')

--- a/infrastructure-provisioning/src/general/scripts/azure/zeppelin_configure.py
+++ b/infrastructure-provisioning/src/general/scripts/azure/zeppelin_configure.py
@@ -192,6 +192,23 @@ if __name__ == "__main__":
         AzureActions().remove_instance(notebook_config['resource_group_name'], notebook_config['instance_name'])
         sys.exit(1)
 
+    try:
+        logging.info('[POST CONFIGURING PROCESS]')
+        print('[POST CONFIGURING PROCESS')
+        if notebook_config['notebook_image_name'] not in [notebook_config['expected_image_name'], 'None']:
+            params = "--hostname {} --keyfile {} --os_user {} --resource_group_name {} --notebook_name {}" \
+                .format(instance_hostname, keyfile_name, notebook_config['dlab_ssh_user'],
+                        notebook_config['resource_group_name'], notebook_config['instance_name'])
+            try:
+                local("~/scripts/{}.py {}".format('common_remove_remote_kernels', params))
+            except:
+                traceback.print_exc()
+                raise Exception
+    except Exception as err:
+        append_result("Failed to post configuring instance.", str(err))
+        AzureActions().remove_instance(notebook_config['resource_group_name'], notebook_config['instance_name'])
+        sys.exit(1)
+
     if notebook_config['shared_image_enabled'] == 'true':
         try:
             print('[CREATING IMAGE]')

--- a/infrastructure-provisioning/src/jupyter/scripts/configure_jupyter_node.py
+++ b/infrastructure-provisioning/src/jupyter/scripts/configure_jupyter_node.py
@@ -135,4 +135,4 @@ if __name__ == "__main__":
     
     #POST INSTALLATION PROCESS
     print("Updating pyOpenSSL library")
-    update_pyopenssl_lib()
+    update_pyopenssl_lib(args.os_user)

--- a/infrastructure-provisioning/src/rstudio/scripts/configure_rstudio_node.py
+++ b/infrastructure-provisioning/src/rstudio/scripts/configure_rstudio_node.py
@@ -107,4 +107,4 @@ if __name__ == "__main__":
     
     #POST INSTALLATION PROCESS
     print("Updating pyOpenSSL library")
-    update_pyopenssl_lib()
+    update_pyopenssl_lib(args.os_user)

--- a/infrastructure-provisioning/src/tensor/scripts/configure_tensor_node.py
+++ b/infrastructure-provisioning/src/tensor/scripts/configure_tensor_node.py
@@ -128,4 +128,4 @@ if __name__ == "__main__":
     
     #POST INSTALLATION PROCESS
     print("Updating pyOpenSSL library")
-    update_pyopenssl_lib()
+    update_pyopenssl_lib(args.os_user)

--- a/infrastructure-provisioning/src/zeppelin/scripts/configure_zeppelin_node.py
+++ b/infrastructure-provisioning/src/zeppelin/scripts/configure_zeppelin_node.py
@@ -246,4 +246,4 @@ if __name__ == "__main__":
     
     #POST INSTALLATION PROCESS
     print("Updating pyOpenSSL library")
-    update_pyopenssl_lib()
+    update_pyopenssl_lib(args.os_user)


### PR DESCRIPTION
Fixed cleaning remote kernels for notebook images, which were created with running dataengine/dataengine-service clusters